### PR TITLE
Shared Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ dP = evaluate_d(basis, x)
 P, dP = evaluate_ed(basis, x)
 
 # second derivatives 
-ddP = evaluate_d2(basis, x)
+ddP = evaluate_dd(basis, x)
 P, dP, ddP = evaluate_ed2(basis, x)
 ```

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,18 +1,85 @@
 
 abstract type AbstractPoly4MLBasis end
 
+# NOTE: Because we don't have a use-case for general arrays, we assume that a 
+#       BATCH is always given as an AbstractVector of SINGLEs. But in principle 
+#       we could allow for more generality here if there is demand for it. 
+
+const SINGLE = Union{Number, StaticArray}
+const BATCH = AbstractVector{<: SINGLE}
+
+# ---------------------------------------
+# managing defaults for input-output types
+
+function _valtype end 
+function _gradtype end 
+function _hesstype end 
+function _laplacetype end 
+
+_gradtype(basis::AbstractPoly4MLBasis, x::Number) = 
+      promote_type(_valtype(basis, x), typeof(x))
+
+_gradtype(basis::AbstractPoly4MLBasis, x::StaticArray) = 
+      StaticArrays.similar_type(typeof(x), promote_type(_valtype(basis, x)))
+
+_hesstype(basis::AbstractPoly4MLBasis, x::Number) = 
+      promote_type(_valtype(basis, x), typeof(x))
+
+_hesstype(basis::AbstractPoly4MLBasis, x::StaticVector) = 
+      StaticArrays.similar_type(typeof(x), promote_type(_valtype(basis, x)))
+
+_laplacetype(basis::AbstractPoly4MLBasis, x::Number) = 
+      _hesstype(basis, x)
+
+_laplacetype(basis::AbstractPoly4MLBasis, x::Number) = 
+      eltype(_hesstype(basis, x))
+
+
+# --------------------------------------- 
+# allocation interface interface 
+
+_alloc(basis::AbstractPoly4MLBasis, x::SINGLE) = 
+      Vector{ _valtype(basis, x) }(undef, length(basis))
+
+_alloc(basis::AbstractPoly4MLBasis, X::BATCH) = 
+      Array{ _valtype(basis, X[1]) }(undef, (length(basis), length(X)))
+
+_alloc_d(basis::AbstractPoly4MLBasis, x::SINGLE) = 
+      Vector{ _gradtype(basis, x) }(undef, length(basis))
+
+_alloc_d(basis::AbstractPoly4MLBasis, X::BATCH) = 
+      Array{ _gradtype(basis, X[1]) }(undef, (length(basis), length(X)))
+
+_alloc_dd(basis::AbstractPoly4MLBasis, x::SINGLE) = 
+      Vector{ _hesstype(basis, x) }(undef, length(basis))
+
+_alloc_dd(basis::AbstractPoly4MLBasis, X::BATCH) = 
+      Array{ _hesstype(basis, X[1]) }(undef, (length(basis), length(X)))
+
+_alloc_ed(basis::AbstractPoly4MLBasis, x) = 
+      _alloc(basis, x), _alloc_d(basis, x)
+
+_alloc_ed2(basis::AbstractPoly4MLBasis, x) = 
+   _alloc(basis, x), _alloc_d(basis, x), _alloc_dd(basis, x)
+
+
+
+# --------------------------------------- 
+# evaluation interface 
+
 (basis::AbstractPoly4MLBasis)(x) = evaluate(basis, x)
             
-evaluate(basis::AbstractPoly4MLBasis, x) = evaluate!(_alloc(basis, x), basis, x)
+evaluate(basis::AbstractPoly4MLBasis, x) = 
+      evaluate!(_alloc(basis, x), basis, x)
 
 evaluate_ed(basis::AbstractPoly4MLBasis, x) = 
-      evaluate_ed!(_alloc(basis, x), _alloc(basis, x), basis, x)
+      evaluate_ed!(_alloc(basis, x), _alloc_d(basis, x), basis, x)
 
 evaluate_d(basis::AbstractPoly4MLBasis, x) = evaluate_ed(basis, x)[2] 
 
 evaluate_ed2(basis::AbstractPoly4MLBasis, x) = 
-      evaluate_ed2!(_alloc(basis, x), _alloc(basis, x), _alloc(basis, x), 
+      evaluate_ed2!(_alloc(basis, x), _alloc_d(basis, x), _alloc_dd(basis, x), 
                     basis, x)
 
-evaluate_d2(basis::AbstractPoly4MLBasis, x) = evaluate_ed2(basis, x)[3] 
+evaluate_dd(basis::AbstractPoly4MLBasis, x) = evaluate_ed2(basis, x)[3] 
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,3 +1,4 @@
+using StaticArrays: StaticArray, SVector, StaticVector, similar_type
 
 abstract type AbstractPoly4MLBasis end
 
@@ -16,45 +17,51 @@ function _gradtype end
 function _hesstype end 
 function _laplacetype end 
 
+_valtype(basis::AbstractPoly4MLBasis, x::Number) = 
+      _valtype(basis, typeof(x))
+
 _gradtype(basis::AbstractPoly4MLBasis, x::Number) = 
       promote_type(_valtype(basis, x), typeof(x))
 
 _gradtype(basis::AbstractPoly4MLBasis, x::StaticArray) = 
-      StaticArrays.similar_type(typeof(x), promote_type(_valtype(basis, x)))
+      StaticArrays.similar_type(typeof(x), 
+                                promote_type(eltype(x), _valtype(basis, x)))
 
 _hesstype(basis::AbstractPoly4MLBasis, x::Number) = 
       promote_type(_valtype(basis, x), typeof(x))
 
-_hesstype(basis::AbstractPoly4MLBasis, x::StaticVector) = 
-      StaticArrays.similar_type(typeof(x), promote_type(_valtype(basis, x)))
+_hesstype(basis::AbstractPoly4MLBasis, x::SVector{N}) where {N} = 
+      SMatrix{N, N, promote_type(_valtype(basis, x), eltype(x))}
 
 _laplacetype(basis::AbstractPoly4MLBasis, x::Number) = 
       _hesstype(basis, x)
 
-_laplacetype(basis::AbstractPoly4MLBasis, x::Number) = 
+_laplacetype(basis::AbstractPoly4MLBasis, x::StaticVector) = 
       eltype(_hesstype(basis, x))
 
 
 # --------------------------------------- 
 # allocation interface interface 
 
+# TODO: here we should work with eltype(BATCH) instead of X[1]
+
 _alloc(basis::AbstractPoly4MLBasis, x::SINGLE) = 
       Vector{ _valtype(basis, x) }(undef, length(basis))
 
 _alloc(basis::AbstractPoly4MLBasis, X::BATCH) = 
-      Array{ _valtype(basis, X[1]) }(undef, (length(basis), length(X)))
+      Array{ _valtype(basis, X[1]) }(undef, (length(X), length(basis)))
 
 _alloc_d(basis::AbstractPoly4MLBasis, x::SINGLE) = 
       Vector{ _gradtype(basis, x) }(undef, length(basis))
 
 _alloc_d(basis::AbstractPoly4MLBasis, X::BATCH) = 
-      Array{ _gradtype(basis, X[1]) }(undef, (length(basis), length(X)))
+      Array{ _gradtype(basis, X[1]) }(undef, (length(X), length(basis)))
 
 _alloc_dd(basis::AbstractPoly4MLBasis, x::SINGLE) = 
       Vector{ _hesstype(basis, x) }(undef, length(basis))
 
 _alloc_dd(basis::AbstractPoly4MLBasis, X::BATCH) = 
-      Array{ _hesstype(basis, X[1]) }(undef, (length(basis), length(X)))
+      Array{ _hesstype(basis, X[1]) }(undef, (length(X), length(basis)))
 
 _alloc_ed(basis::AbstractPoly4MLBasis, x) = 
       _alloc(basis, x), _alloc_d(basis, x)
@@ -69,17 +76,25 @@ _alloc_ed2(basis::AbstractPoly4MLBasis, x) =
 
 (basis::AbstractPoly4MLBasis)(x) = evaluate(basis, x)
             
-evaluate(basis::AbstractPoly4MLBasis, x) = 
-      evaluate!(_alloc(basis, x), basis, x)
+function evaluate(basis::AbstractPoly4MLBasis, x) 
+   B = _alloc(basis, x)
+   evaluate!(B, basis, x)
+   return B 
+end
 
-evaluate_ed(basis::AbstractPoly4MLBasis, x) = 
-      evaluate_ed!(_alloc(basis, x), _alloc_d(basis, x), basis, x)
+function evaluate_ed(basis::AbstractPoly4MLBasis, x) 
+   B, dB = _alloc_ed(basis, x)
+   evaluate_ed!(B, dB, basis, x)
+   return B, dB
+end 
 
 evaluate_d(basis::AbstractPoly4MLBasis, x) = evaluate_ed(basis, x)[2] 
 
-evaluate_ed2(basis::AbstractPoly4MLBasis, x) = 
-      evaluate_ed2!(_alloc(basis, x), _alloc_d(basis, x), _alloc_dd(basis, x), 
-                    basis, x)
+function evaluate_ed2(basis::AbstractPoly4MLBasis, x)
+   B, dB, ddB = _alloc_ed2(basis, x)
+   evaluate_ed2!(B, dB, ddB, basis, x)
+   return B, dB, ddB
+end
 
 evaluate_dd(basis::AbstractPoly4MLBasis, x) = evaluate_ed2(basis, x)[3] 
 

--- a/src/lux.jl
+++ b/src/lux.jl
@@ -43,8 +43,6 @@ initialparameters(rng::AbstractRNG, l::PolyLuxLayer) = _init_luxparams(rng, l.ba
 
 initialstates(rng::AbstractRNG, l::PolyLuxLayer) = _init_luxstate(rng, l.basis)
 
-const SINGLE = Union{Number, StaticVector}
-
 (l::PolyLuxLayer)(args...) = evaluate(l, args...)
 
 function evaluate(l::PolyLuxLayer, x::SINGLE, ps, st)

--- a/src/rtrig.jl
+++ b/src/rtrig.jl
@@ -32,10 +32,6 @@ RTrigBasis(N::Integer, meta = Dict{String, Any}()) =
 
 _valtype(basis::RTrigBasis, x::Real) = typeof(x) 
 
-_alloc(basis::RTrigBasis, x::Real) = zeros(typeof(x), length(basis))
-
-_alloc(basis::RTrigBasis, x::AbstractVector{<: Real}) = zeros(eltype(x), length(x), length(basis))
-
 
 function evaluate!(P::AbstractVector, basis::RTrigBasis, θ::Real)
    N = basis.N 

--- a/src/sphericalharmonics/cylm.jl
+++ b/src/sphericalharmonics/cylm.jl
@@ -48,17 +48,17 @@ maxL(sh::CYlmBasis) = sh.alp.L
 _valtype(sh::CYlmBasis{T}, x::AbstractVector{S}) where {T <: Real, S <: Real} = 
 			Complex{promote_type(T, S)}
 
-_gradtype(sh::CYlmBasis{T}, x::AbstractVector{S})  where {T <: Real, S <: Real} = 
-			SVector{3, Complex{promote_type(T, S)}}
-
-import Base.==
-==(B1::CYlmBasis, B2::CYlmBasis) =
-		(B1.alp == B2.alp) && (typeof(B1) == typeof(B2))
+# _gradtype(sh::CYlmBasis{T}, x::AbstractVector{S})  where {T <: Real, S <: Real} = 
+# 			SVector{3, Complex{promote_type(T, S)}}
 
 Base.length(basis::CYlmBasis) = sizeY(maxL(basis))
 
 
 # ---------------------- FIO
+
+import Base.==
+==(B1::CYlmBasis, B2::CYlmBasis) =
+		(B1.alp == B2.alp) && (typeof(B1) == typeof(B2))
 
 # write_dict(SH::CYlmBasis{T}) where {T} =
 # 		Dict("__id__" => "ACE_CYlmBasis",
@@ -73,11 +73,11 @@ Base.length(basis::CYlmBasis) = sizeY(maxL(basis))
 
 # ---------------------- evaluation interface code 
 
-function evaluate(basis::CYlmBasis, x::AbstractVector{<: Real})
-	Y = acquire!(basis.pool, length(basis), _valtype(basis, x))
-	evaluate!(parent(Y), basis, x)
-	return Y 
-end
+# function evaluate(basis::CYlmBasis, x::AbstractVector{<: Real})
+# 	Y = acquire!(basis.pool, length(basis), _valtype(basis, x))
+# 	evaluate!(parent(Y), basis, x)
+# 	return Y 
+# end
 
 function evaluate!(Y, basis::CYlmBasis, x::AbstractVector{<: Real})
 	L = maxL(basis)
@@ -88,11 +88,11 @@ function evaluate!(Y, basis::CYlmBasis, x::AbstractVector{<: Real})
 	return Y
 end
 
-function evaluate(basis::CYlmBasis, X::AbstractVector{<: AbstractVector})
-	Y = acquire!(basis.ppool, (length(X), length(basis)))
-	evaluate!(parent(Y), basis, X)
-	return Y 
-end
+# function evaluate(basis::CYlmBasis, X::AbstractVector{<: AbstractVector})
+# 	Y = acquire!(basis.ppool, (length(X), length(basis)))
+# 	evaluate!(parent(Y), basis, X)
+# 	return Y 
+# end
 
 function evaluate!(Y, basis::CYlmBasis, 
 						 X::AbstractVector{<: AbstractVector})
@@ -106,20 +106,20 @@ function evaluate!(Y, basis::CYlmBasis,
 end
 
 
-function evaluate_d(SH::CYlmBasis, 
-						 R::Union{AbstractVector{<: Real}, 
-						 			 AbstractVector{<: AbstractVector}} )
-	B, dB = evaluate_ed(SH, R) 
-	release!(B)
-	return dB 
-end 
+# function evaluate_d(SH::CYlmBasis, 
+# 						 R::Union{AbstractVector{<: Real}, 
+# 						 			 AbstractVector{<: AbstractVector}} )
+# 	B, dB = evaluate_ed(SH, R) 
+# 	release!(B)
+# 	return dB 
+# end 
 
-function evaluate_ed(SH::CYlmBasis, R::AbstractVector{<: Real})
-	Y = acquire!(SH.pool, length(SH), _valtype(SH, R))
-	dY = acquire!(SH.pool_d, length(SH), _gradtype(SH, R))
-	evaluate_ed!(parent(Y), parent(dY), SH, R)
-	return Y, dY
-end
+# function evaluate_ed(SH::CYlmBasis, R::AbstractVector{<: Real})
+# 	Y = acquire!(SH.pool, length(SH), _valtype(SH, R))
+# 	dY = acquire!(SH.pool_d, length(SH), _gradtype(SH, R))
+# 	evaluate_ed!(parent(Y), parent(dY), SH, R)
+# 	return Y, dY
+# end
 
 function evaluate_ed!(Y, dY, SH::CYlmBasis, R::AbstractVector{<: Real})
 	L = maxL(SH)
@@ -132,13 +132,13 @@ function evaluate_ed!(Y, dY, SH::CYlmBasis, R::AbstractVector{<: Real})
 end
 
 
-function evaluate_ed(SH::CYlmBasis, R::AbstractVector{<: AbstractVector})
-	nR = length(R); nY = length(SH)
-	Y = acquire!(SH.ppool, (nR, nY), _valtype(SH, R[1]))
-	dY = acquire!(SH.ppool_d, (nR, nY), _gradtype(SH, R[1]))
-	evaluate_ed!(parent(Y), parent(dY), SH, R)
-	return Y, dY
-end
+# function evaluate_ed(SH::CYlmBasis, R::AbstractVector{<: AbstractVector})
+# 	nR = length(R); nY = length(SH)
+# 	Y = acquire!(SH.ppool, (nR, nY), _valtype(SH, R[1]))
+# 	dY = acquire!(SH.ppool_d, (nR, nY), _gradtype(SH, R[1]))
+# 	evaluate_ed!(parent(Y), parent(dY), SH, R)
+# 	return Y, dY
+# end
 
 function evaluate_ed!(Y, dY, SH::CYlmBasis, R::AbstractVector{<: AbstractVector})
 	L = maxL(SH)

--- a/src/sphericalharmonics/rylm.jl
+++ b/src/sphericalharmonics/rylm.jl
@@ -56,11 +56,11 @@ Base.show(io::IO, basis::RYlmBasis) =
 
 # ---------------------- Interfaces
 
-function evaluate(basis::RYlmBasis, x::AbstractVector{<: Real})
-	Y = acquire!(basis.pool, length(basis), _valtype(basis, x))
-	evaluate!(parent(Y), basis, x)
-	return Y 
-end
+# function evaluate(basis::RYlmBasis, x::AbstractVector{<: Real})
+# 	Y = acquire!(basis.pool, length(basis), _valtype(basis, x))
+# 	evaluate!(parent(Y), basis, x)
+# 	return Y 
+# end
 
 function evaluate!(Y, basis::RYlmBasis, x::AbstractVector{<: Real})
 	L = maxL(basis)
@@ -71,11 +71,11 @@ function evaluate!(Y, basis::RYlmBasis, x::AbstractVector{<: Real})
 	return nothing 
 end
 
-function evaluate(basis::RYlmBasis, X::AbstractVector{<: AbstractVector})
-	Y = acquire!(basis.bpool, (length(X), length(basis)))
-	evaluate!(parent(Y), basis, X)
-	return Y 
-end
+# function evaluate(basis::RYlmBasis, X::AbstractVector{<: AbstractVector})
+# 	Y = acquire!(basis.bpool, (length(X), length(basis)))
+# 	evaluate!(parent(Y), basis, X)
+# 	return Y 
+# end
 
 function evaluate!(Y, basis::RYlmBasis, 
 						 X::AbstractVector{<: AbstractVector{<: Real}})
@@ -89,12 +89,12 @@ function evaluate!(Y, basis::RYlmBasis,
 end
 
 
-function evaluate_ed(basis::RYlmBasis, x::AbstractVector{<: Real})
-	Y = acquire!(basis.pool, length(basis))
-	dY = acquire!(basis.pool_d, length(basis))
-	evaluate_ed!(parent(Y), parent(dY), basis, x)
-	return Y, dY 
-end
+# function evaluate_ed(basis::RYlmBasis, x::AbstractVector{<: Real})
+# 	Y = acquire!(basis.pool, length(basis))
+# 	dY = acquire!(basis.pool_d, length(basis))
+# 	evaluate_ed!(parent(Y), parent(dY), basis, x)
+# 	return Y, dY 
+# end
 
 function evaluate_ed!(Y, dY, basis::RYlmBasis, 
 						     x::AbstractVector{<: Real})
@@ -108,12 +108,12 @@ function evaluate_ed!(Y, dY, basis::RYlmBasis,
 end
 
 
-function evaluate_ed(basis::RYlmBasis, X::AbstractVector{<: AbstractVector{<: Real}})
-	Y = acquire!(basis.bpool, (length(X), length(basis)))
-	dY = acquire!(basis.bpool_d, (length(X), length(basis)))
-	evaluate_ed!(parent(Y), parent(dY), basis, X)
-	return Y, dY 
-end
+# function evaluate_ed(basis::RYlmBasis, X::AbstractVector{<: AbstractVector{<: Real}})
+# 	Y = acquire!(basis.bpool, (length(X), length(basis)))
+# 	dY = acquire!(basis.bpool_d, (length(X), length(basis)))
+# 	evaluate_ed!(parent(Y), parent(dY), basis, X)
+# 	return Y, dY 
+# end
 
 function evaluate_ed!(Y, dY, basis::RYlmBasis, 
 						     X::AbstractVector{<: AbstractVector{<: Real}})

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -1,7 +1,7 @@
 module Testing
 
 using Polynomials4ML: evaluate!, evaluate_ed!, evaluate_ed2!, 
-               evaluate, evaluate_d, evaluate_ed, evaluate_d2, evaluate_ed2 , 
+               evaluate, evaluate_d, evaluate_ed, evaluate_dd, evaluate_ed2 , 
                _alloc
 
 using Test, ForwardDiff
@@ -52,7 +52,7 @@ function test_derivatives(basis, generate_x, nX = 32, ntest = 8)
       P2, dP2 = evaluate_ed(basis, x)
       dP3 = evaluate_d(basis, x)
       P4, dP4, ddP4 = evaluate_ed2(basis, x)
-      ddP5 = evaluate_d2(basis, x)
+      ddP5 = evaluate_dd(basis, x)
       print_tf(@test P1 ≈ P2 ≈ P4 )
       print_tf(@test dP2 ≈ dP3 ≈ dP4)
       print_tf(@test ddP4 ≈ ddP5)
@@ -81,7 +81,7 @@ function test_derivatives(basis, generate_x, nX = 32, ntest = 8)
    for (i, x) in enumerate(X)
       bP1[i, :] = evaluate(basis, x)
       bdP1[i, :] = evaluate_d(basis, x)
-      bddP1[i, :] = evaluate_d2(basis, x)
+      bddP1[i, :] = evaluate_dd(basis, x)
    end
       
    bP2 = evaluate(basis, X)

--- a/src/trig.jl
+++ b/src/trig.jl
@@ -24,7 +24,6 @@ CTrigBasis(N::Integer, T = Float64, meta = Dict{String, Any}()) =
 # ----------------- interface functions 
 
 
-
 natural_indices(basis::CTrigBasis) = -basis.N:basis.N 
 
 index(basis::CTrigBasis, m::Integer) = 
@@ -34,13 +33,6 @@ index(basis::CTrigBasis, m::Integer) =
 Base.length(basis::CTrigBasis) = 2 * basis.N + 1 
 
 _valtype(basis::CTrigBasis, x::Real) = complex(typeof(x))
-
-_alloc(basis::CTrigBasis{T1}, x::T2) where {T1, T2 <: Number} = 
-            zeros(promote_type(Complex{T1}, T2), length(basis))
-
-_alloc(basis::CTrigBasis{T1}, X::AbstractVector{T2}) where {T1, T2 <: Number} = 
-            zeros(promote_type(Complex{T1}, T2), length(X), length(basis))
-
 
             
 # ----------------- main evaluation code 
@@ -155,6 +147,7 @@ function evaluate_ed!(P, dP, basis::CTrigBasis, X::AbstractVector)
    @inbounds begin 
       for i = 1:nX 
          P[i, 1] = 1 
+         dP[i, 1] = 0
          s, c = sincos(X[i])
          P[i, 2] = Complex(c, s)
          dP[i, 2] = Complex(-s, c)
@@ -188,6 +181,8 @@ function evaluate_ed2!(P, dP, ddP, basis::CTrigBasis, X::AbstractVector)
    @inbounds begin 
       for i = 1:nX 
          P[i, 1] = 1 
+         dP[i, 1] = 0 
+         ddP[i, 1] = 0
          s, c = sincos(X[i])
          P[i, 2] = Complex(c, s)
          dP[i, 2] = Complex(-s, c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using Test
     @testset "TrigonometricPolynomials" begin include("test_trig.jl"); end
     @testset "Real Trig Polys" begin include("test_rtrig.jl"); end
     @testset "SphericalHarmonics" begin include("test_cylm.jl"); end
-    @testset "SphericalHarmonics" begin include("test_rylm.jl"); end
+    @testset "Real Spherical Harmonics" begin include("test_rylm.jl"); end
 
     @testset "Lux" begin include("test_lux.jl"); end 
 end

--- a/test/test_op1d3t.jl
+++ b/test/test_op1d3t.jl
@@ -1,6 +1,6 @@
 
 using Polynomials4ML, Test
-using Polynomials4ML: evaluate, evaluate_d, evaluate_d2
+using Polynomials4ML: evaluate, evaluate_d, evaluate_dd
 using Polynomials4ML.Testing: println_slim, test_derivatives
 using LinearAlgebra: I
 using QuadGK
@@ -12,11 +12,10 @@ using QuadGK
 
 for ntest = 1:3
    @info("Test a randomly generated polynomial basis - $ntest")
-   N = rand(10:15)
+   N = rand(5:15)
    basis = OrthPolyBasis1D3T(randn(N), randn(N), randn(N))
    test_derivatives(basis, () -> rand())
 end
-
 
 ##
 
@@ -48,26 +47,43 @@ end
 
 ##
 
-@warn("turn off Chebyshev test - coeffs seem poorly normalized?!?")
 using LinearAlgebra: norm
-cheb = chebyshev_basis(N, normalize=true)
-@show abs(cheb.A[1] - sqrt(1/π))
-@show abs(cheb.A[2] - sqrt(2/π))
-@show abs(cheb.C[3] + sqrt(2))
-@show norm(cheb.A[3:end] .- 2, Inf)
-@show norm(cheb.B, Inf)
-@show norm(cheb.C[4:end] .+ 1)
 
-# @info("Check correctness of Chebyshev Basis")
+# @warn("turn off Chebyshev test - coeffs seem poorly normalized?!?")
 # cheb = chebyshev_basis(N, normalize=true)
+# @show abs(cheb.A[1] - sqrt(1/π))
+# @show abs(cheb.A[2] - sqrt(2/π))
+# @show abs(cheb.C[3] + sqrt(2))
+# @show norm(cheb.A[3:end] .- 2, Inf)
+# @show norm(cheb.B, Inf)
+# @show norm(cheb.C[4:end] .+ 1)
+
+# TODO: add standard chebyshev and add it to the test suite
+# @info("Check correctness of Chebyshev Basis (normalize=false)")
+# cheb = chebyshev_basis(N, normalize=false)
 # @info("     recursion coefficients")
 # println_slim(@test all([ 
-#          cheb.A[1] ≈ sqrt(1/π), 
+#          cheb.A[1] ≈ 1, 
 #          all(cheb.B[:] .== 0), 
-#          cheb.A[2] ≈ sqrt(2/π), 
+#          cheb.A[2] ≈ 1, 
 #          all(cheb.A[3:end] .≈ 2), 
 #          cheb.C[3] ≈ - sqrt(2), 
-#          all(cheb.C[4:end] .≈ -1), ]))         
+#          all(cheb.C[4:end] .≈ -1), ]))
+# @info("     derivatives")
+
+
+##
+
+@info("Test Chebyshev Basis (normalize=true)")
+cheb = chebyshev_basis(N, normalize=true)
+@info("     recursion coefficients")
+println_slim(@test all([ 
+         abs(cheb.A[1] - sqrt(1/π)) < 1e-7,
+         abs(cheb.A[2] - sqrt(2/π)) < 1e-7,
+         abs(cheb.C[3] + sqrt(2)) < 1e-7,
+         norm(cheb.A[3:end] .- 2, Inf) < 1e-7,
+         norm(cheb.B, Inf) < 1e-7,
+         norm(cheb.C[4:end] .+ 1) < 1e-7, ]))
 @info("     derivatives")
 test_derivatives(cheb, () -> 2*rand()-1)
 

--- a/test/test_rtrig.jl
+++ b/test/test_rtrig.jl
@@ -1,5 +1,5 @@
 using Polynomials4ML, Test
-using Polynomials4ML: evaluate, evaluate_d, evaluate_d2
+using Polynomials4ML: evaluate, evaluate_d, evaluate_dd
 using Polynomials4ML.Testing: println_slim, print_tf, test_derivatives
 
 

--- a/test/test_rylm.jl
+++ b/test/test_rylm.jl
@@ -32,6 +32,8 @@ function test_r2c(L, cY, rY)
    return cY ≈ cYt
 end
 
+##
+
 maxL = 20
 cSH = CYlmBasis(maxL)
 rSH = RYlmBasis(maxL)

--- a/test/test_trig.jl
+++ b/test/test_trig.jl
@@ -1,7 +1,7 @@
 
 
 using Polynomials4ML, Test
-using Polynomials4ML: evaluate, evaluate_d, evaluate_d2
+using Polynomials4ML: evaluate, evaluate_d, evaluate_dd
 using Polynomials4ML.Testing: println_slim, print_tf, test_derivatives
 
 


### PR DESCRIPTION
This PR is intended to remove a lot of duplicated functionality by taking all bases to have a shared abstract supertype and then writing out the fairly easy rules that the output types are and how the resulting outputs are allocated.