### PR TITLE
Embed and pool

### DIFF
--- a/src/Polynomials4ML.jl
+++ b/src/Polynomials4ML.jl
@@ -75,6 +75,9 @@ include("lux.jl")
 # basis components to implement cluster expansion methods
 include("ace/ace.jl")
 
+# pooled embeddings
+include("pooledembeddings.jl")
+
 # some nice utility functions to generate basis sets and other things  
 include("utils/utils.jl")
 

--- a/src/PooledEmbeddings.jl
+++ b/src/PooledEmbeddings.jl
@@ -1,0 +1,38 @@
+using Polynomials4ML: AbstractPoly4MLBasis, PooledSparseProduct
+
+export PooledEmebddings
+
+struct PooledEmebddings{NB, TB <: Tuple} <: AbstractPoly4MLBasis
+   embeddings::TB
+   pooling::PooledSparseProduct{NB}
+   @reqfields()
+end
+
+function PooledEmebddings(embeddings, pooling)
+   return PooledEmebddings(embeddings, pooling, _make_reqfields()...)
+end
+
+import Base.Cartesian: @nexprs
+
+function _write_code_Bi_tup(NB)
+   Bi_tup_str = "(B_1, "
+   for i = 2:NB-1
+      Bi_tup_str *= "B_$i, "
+   end
+   Bi_tup_str *= "B_$NB)"
+   return Bi_tup_str
+end
+
+@generated function evaluate(basis::PooledEmebddings{NB, TB}, X)
+   @assert NB > 0
+   quote
+      @nexprs $NB i -> begin
+         embed_i = basis.embeddings[i]
+         B_i = evaluate(embed_i, X)
+      end
+      A = basis.pooling($_write_code_Bi_tup(NB))
+      @nexprs $NB i -> release!(B_i)
+
+      return A
+   end
+end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -135,7 +135,7 @@ _alloc_ed2(basis::AbstractPoly4MLBasis, x) =
       _alloc(basis, x), _alloc_d(basis, x), _alloc_dd(basis, x)
 
 # --------------------------------------- 
-# evaluation interface 
+# general evaluation interface 
 
 (basis::AbstractPoly4MLBasis)(x) = evaluate(basis, x)
             
@@ -144,6 +144,18 @@ function evaluate(basis::AbstractPoly4MLBasis, x)
    evaluate!(unwrap(B), basis, x)
    return B 
 end
+
+# function evaluate(basis::ScalarPoly4MLBasis, x::Vector{SVector{3, S}})  where {S <: real}
+#    nX = length(X)
+#    R = acquire!(basis.pool, :R, (nX,), T)
+#    @simd ivdep for i = 1:Nel
+#       R[i] = norm(X[i])
+#    end
+#    B = _alloc(basis, R)
+#    evaluate!(unwrap(B), basis, R)
+#    release!(R)
+#    return B 
+# end
 
 function evaluate_ed(basis::AbstractPoly4MLBasis, x) 
    B, dB = _alloc_ed(basis, x)
@@ -160,7 +172,6 @@ end
 evaluate_d(basis::AbstractPoly4MLBasis, x) = evaluate_ed(basis, x)[2] 
 
 evaluate_dd(basis::AbstractPoly4MLBasis, x) = evaluate_ed2(basis, x)[3] 
-
 
 # the next set of interface functions are in-place but work a little 
 # differently : by using a FlexArray as input the evaluation function 

--- a/src/orthopolybasis.jl
+++ b/src/orthopolybasis.jl
@@ -52,7 +52,7 @@ _valtype(basis::OrthPolyBasis1D3T{T}, ::Type{<: StaticVector{3, S}}) where {T <:
 # x can be any object for which a polynomial could be defined, but normally 
 #     a number. x cannot be an abstractvector since this would dispatch to a 
 #     different method. 
-function evaluate!(P::AbstractArray, basis::OrthPolyBasis1D3T, x) 
+function evaluate!(P::AbstractArray, basis::OrthPolyBasis1D3T, x::Number) 
    N = length(basis.A)
    @assert length(P) >= N 
    @inbounds P[1] = basis.A[1]
@@ -112,7 +112,7 @@ end
 
 # P should be a matrix now and we will write basis(X[i]) into P[i, :]; 
 # this is the format the optimizes memory access. 
-function evaluate!(P::AbstractArray, basis::OrthPolyBasis1D3T, X::AbstractVector) 
+function evaluate!(P::AbstractArray, basis::OrthPolyBasis1D3T, X::AbstractVector{T}) where T <: Number
    N = length(basis.A)
    nX = length(X) 
    # ------- do the bounds checks here 

--- a/src/orthopolybasis.jl
+++ b/src/orthopolybasis.jl
@@ -41,6 +41,11 @@ Base.length(basis::OrthPolyBasis1D3T) = length(basis.A)
 _valtype(basis::OrthPolyBasis1D3T{T1}, TX::Type{T2}) where {T1, T2} = 
             promote_type(T1, T2)         
 
+_valtype(basis::OrthPolyBasis1D3T{T}, ::Type{<: StaticVector{3, S}}) where {T <: Real, S <: Real} = 
+		promote_type(T, S)
+
+# _valtype(basis::OrthPolyBasis1D3T{T}, ::Type{<: StaticVector{3, Hyper{S}}}) where {T <: Real, S <: Real} = 
+# 		promote_type(T, Hyper{S})
 # ----------------- main evaluation code 
 
 # P must be a preallocated output vector of suitable length 

--- a/src/pooledembeddings.jl
+++ b/src/pooledembeddings.jl
@@ -1,6 +1,10 @@
-using Polynomials4ML: AbstractPoly4MLBasis, PooledSparseProduct
-
 export PooledEmebddings
+
+using ChainRulesCore: NoTangent
+using Polynomials4ML: PooledSparseProduct, AbstractPoly4MLBasis
+
+import ChainRulesCore: rrule
+import Base.Cartesian: @nexprs
 
 struct PooledEmebddings{NB, TB <: Tuple} <: AbstractPoly4MLBasis
    embeddings::TB
@@ -12,7 +16,7 @@ function PooledEmebddings(embeddings, pooling)
    return PooledEmebddings(embeddings, pooling, _make_reqfields()...)
 end
 
-import Base.Cartesian: @nexprs
+Base.length(basis::PooledEmebddings) = length(basis.pooling)
 
 function _write_code_Bi_tup(NB)
    Bi_tup_str = "(B_1, "
@@ -20,19 +24,59 @@ function _write_code_Bi_tup(NB)
       Bi_tup_str *= "B_$i, "
    end
    Bi_tup_str *= "B_$NB)"
-   return Bi_tup_str
+   return Meta.parse(Bi_tup_str)
 end
 
-@generated function evaluate(basis::PooledEmebddings{NB, TB}, X)
+# TODO: generalize to any X
+@generated function evaluate(basis::PooledEmebddings{NB, TB}, X::Vector{SVector{3, T}}) where {NB, TB, T}
    @assert NB > 0
+   B_tup = _write_code_Bi_tup(NB)
    quote
       @nexprs $NB i -> begin
          embed_i = basis.embeddings[i]
          B_i = evaluate(embed_i, X)
       end
-      B_tup = _write_code_Bi_tup(NB)
-      A = basis.pooling($B_tup)
+      A = evaluate(basis.pooling, $B_tup)
       @nexprs $NB i -> release!(B_i)
       return A
+   end
+end
+
+function ChainRulesCore.rrule(::typeof(evaluate), basis::PooledEmebddings{NB, TB}, X::Vector{SVector{3, T}}) where {NB, TB, T}
+   @show "Calling correct rrule"
+   A = evaluate(basis, X)
+   return A, Δ -> _evaluate_pb(basis, Δ, X)
+end
+
+@generated function _evaluate_pb(basis::PooledEmebddings{NB, TB}, Δ, X) where {NB, TB}
+   B_tup = _write_code_Bi_tup(NB)
+   quote
+      # evaluate
+      @nexprs $NB i -> begin
+         embed_i = basis.embeddings[i]
+         B_i = evaluate(embed_i, X)
+      end
+      A = evaluate(basis.pooling, $B_tup)
+
+      # pooling
+      pooling_out, pooling_pb = ChainRulesCore.rrule(evaluate, basis.pooling, $B_tup)
+
+      # get the embedding pullbacks
+      @nexprs $NB i -> begin
+         _, embed_pb_i = ChainRulesCore.rrule(evaluate, basis.embeddings[i], X)    
+      end
+      
+      # pooling_pb : Vec -> (B_1, B_2, ..., B_NB)
+      # embed_pb_i : B_i -> ∂X
+      # use 3 since the interface must return (NoTangent(), NoTangent(), ∂)
+      ∂X = zero(X)
+      ∂BBs = pooling_pb(Δ)[3]
+      # writes and accumulate to ∂X
+      @nexprs $NB i -> begin
+         ∂X_i = embed_pb_i(∂BBs[i])
+         ∂X .+= ∂X_i[3]
+      end
+      @show ∂X
+      return (NoTangent(), NoTangent(), ∂X)
    end
 end

--- a/src/pooledembeddings.jl
+++ b/src/pooledembeddings.jl
@@ -28,7 +28,7 @@ function _write_code_Bi_tup(NB)
 end
 
 # TODO: generalize to any X
-@generated function evaluate(basis::PooledEmebddings{NB, TB}, X::Vector{SVector{3, T}}) where {NB, TB, T}
+@generated function evaluate(basis::PooledEmebddings{NB, TB}, X) where {NB, TB, T}
    @assert NB > 0
    B_tup = _write_code_Bi_tup(NB)
    quote
@@ -42,8 +42,7 @@ end
    end
 end
 
-function ChainRulesCore.rrule(::typeof(evaluate), basis::PooledEmebddings{NB, TB}, X::Vector{SVector{3, T}}) where {NB, TB, T}
-   @show "Calling correct rrule"
+function ChainRulesCore.rrule(::typeof(evaluate), basis::PooledEmebddings{NB, TB}, X) where {NB, TB}
    A = evaluate(basis, X)
    return A, Δ -> _evaluate_pb(basis, Δ, X)
 end
@@ -76,7 +75,6 @@ end
          ∂X_i = embed_pb_i(∂BBs[i])
          ∂X .+= ∂X_i[3]
       end
-      @show ∂X
       return (NoTangent(), NoTangent(), ∂X)
    end
 end

--- a/src/pooledembeddings.jl
+++ b/src/pooledembeddings.jl
@@ -30,9 +30,9 @@ end
          embed_i = basis.embeddings[i]
          B_i = evaluate(embed_i, X)
       end
-      A = basis.pooling($_write_code_Bi_tup(NB))
+      B_tup = _write_code_Bi_tup(NB)
+      A = basis.pooling($B_tup)
       @nexprs $NB i -> release!(B_i)
-
       return A
    end
 end

--- a/test/test_pooledembeddings.jl
+++ b/test/test_pooledembeddings.jl
@@ -1,0 +1,135 @@
+
+
+module PooledEmbed
+using Polynomials4ML: AbstractPoly4MLBasis, PooledSparseProduct
+using Polynomials4ML: @reqfields, POOL, TMP, _make_reqfields, META, evaluate
+using Polynomials4ML
+using StaticArrays
+using ObjectPools: release!, acquire!
+using ChainRulesCore
+struct PooledEmebddings{NB, TB <: Tuple} <: AbstractPoly4MLBasis
+   embeddings::TB
+   pooling::PooledSparseProduct{NB}
+   @reqfields()
+end
+
+function PooledEmebddings(embeddings, pooling)
+   return PooledEmebddings(embeddings, pooling, _make_reqfields()...)
+end
+
+Base.length(basis::PooledEmebddings) = length(basis.pooling)
+
+import Base.Cartesian: @nexprs
+
+function _write_code_Bi_tup(NB)
+   Bi_tup_str = "(B_1, "
+   for i = 2:NB-1
+      Bi_tup_str *= "B_$i, "
+   end
+   Bi_tup_str *= "B_$NB)"
+   return Meta.parse(Bi_tup_str)
+end
+
+@generated function myevaluate(basis::PooledEmebddings{NB, TB}, X::Vector{SVector{3, T}}) where {NB, TB, T}
+   @assert NB > 0
+   B_tup = _write_code_Bi_tup(NB)
+   quote
+      @nexprs $NB i -> begin
+         embed_i = basis.embeddings[i]
+         B_i = evaluate(embed_i, X)
+      end
+      A = evaluate(basis.pooling, $B_tup)
+      @nexprs $NB i -> release!(B_i)
+      return A
+   end
+end
+
+function ChainRulesCore.rrule(::typeof(myevaluate), basis::PooledEmebddings{NB, TB}, X::Vector{SVector{3, T}}) where {NB, TB, T}
+   A = myevaluate(basis, X)
+   return A, Δ -> _evaluate_pb(basis, Δ, X)
+end
+
+@generated function _evaluate_pb(basis::PooledEmebddings{NB, TB}, Δ, X) where {NB, TB}
+   B_tup = _write_code_Bi_tup(NB)
+   quote
+      @nexprs $NB i -> begin
+         embed_i = basis.embeddings[i]
+         B_i = evaluate(embed_i, X)
+      end
+      A = evaluate(basis.pooling, $B_tup)
+      pooling_out, pooling_pb = ChainRulesCore.rrule(evaluate, basis.pooling, $B_tup)
+      @nexprs $NB i -> begin
+         _, embed_pb_i = ChainRulesCore.rrule(evaluate, basis.embeddings[i], X)    
+      end
+      # pooling_pb : Vec -> (B_1, B_2, ..., B_NB)
+      # embed_pb_i : B_i -> ∂X
+      ∂X = similar(X)
+      BBs = pooling_pb(Δ)[3]
+      @show typeof(BBs)
+      @nexprs $NB i -> begin
+         ∂X_i = embed_pb_i(BBs[i])
+         @show typeof(∂X_i)
+         ∂X .+= ∂X_i[3]
+      end
+      @show ∂X
+      return ∂X
+   end
+end
+
+end # module PooledEmbed
+
+using Polynomials4ML: legendre_basis, RYlmBasis, ScalarPoly4MLBasis, PooledSparseProduct, OrthPolyBasis1D3T
+using StaticArrays, LinearAlgebra
+using ObjectPools: acquire!, release!
+using Polynomials4ML
+
+function _generate_basis(; order=2, len = 50)
+   NN = [ rand(5:10) for _ = 1:order ]
+   spec = sort([ ntuple(t -> rand(1:NN[t]), order) for _ = 1:len])
+   return PooledSparseProduct(spec)
+end
+
+function Polynomials4ML.evaluate!(Y::AbstractArray, basis::OrthPolyBasis1D3T, X::Vector{SVector{3, T}}) where T
+   nX = length(X)
+   R = acquire!(basis.pool, :R, (nX,), T)
+   @simd ivdep for i = 1:nX
+      R[i] = norm(X[i])
+   end    
+   evaluate!(Y, basis, R)
+   release!(R)
+	return Y
+end
+using ChainRulesCore
+function ChainRulesCore.rrule(::typeof(Polynomials4ML.evaluate), basis::OrthPolyBasis1D3T, X::Vector{SVector{3, T}}) where T
+   R = norm.(X)
+   P, dP = evaluate_ed(basis, R)
+
+   function pb(∂)
+      ∂X = similar(X)
+      for n = 1:size(dP, 2)
+         @simd ivdep for a = 1:length(X)
+            ∂X[a] += ∂[a, n] * dP[a, n] * X[a] / R[a]
+         end
+      end
+      return (NoTangent(), NoTangent(), ∂X)
+   end
+
+  return Y, pb
+end
+
+Polynomials4ML._valtype(basis::OrthPolyBasis1D3T{T}, ::Type{<: StaticVector{3, S}}) where {T <: Real, S <: Real} = promote_type(T, S)
+
+Rnl = legendre_basis(10)
+Ylm = RYlmBasis(10)
+
+pooling = _generate_basis()
+
+X = [ @SVector(randn(3)) for i in 1:3 ]
+
+embeddings = (Rnl, Ylm)
+embed_and_pool = PooledEmbed.PooledEmebddings(embeddings, pooling)
+Main.PooledEmbed.myevaluate(embed_and_pool, X)
+using Zygote
+out, pb = Zygote.pullback(X -> Main.PooledEmbed.myevaluate(embed_and_pool, X), X)
+
+pb(out)

--- a/test/test_pooledembeddings.jl
+++ b/test/test_pooledembeddings.jl
@@ -1,84 +1,4 @@
-
-
-module PooledEmbed
-using Polynomials4ML: AbstractPoly4MLBasis, PooledSparseProduct
-using Polynomials4ML: @reqfields, POOL, TMP, _make_reqfields, META, evaluate
-using Polynomials4ML
-using StaticArrays
-using ObjectPools: release!, acquire!
-using ChainRulesCore
-struct PooledEmebddings{NB, TB <: Tuple} <: AbstractPoly4MLBasis
-   embeddings::TB
-   pooling::PooledSparseProduct{NB}
-   @reqfields()
-end
-
-function PooledEmebddings(embeddings, pooling)
-   return PooledEmebddings(embeddings, pooling, _make_reqfields()...)
-end
-
-Base.length(basis::PooledEmebddings) = length(basis.pooling)
-
-import Base.Cartesian: @nexprs
-
-function _write_code_Bi_tup(NB)
-   Bi_tup_str = "(B_1, "
-   for i = 2:NB-1
-      Bi_tup_str *= "B_$i, "
-   end
-   Bi_tup_str *= "B_$NB)"
-   return Meta.parse(Bi_tup_str)
-end
-
-@generated function myevaluate(basis::PooledEmebddings{NB, TB}, X::Vector{SVector{3, T}}) where {NB, TB, T}
-   @assert NB > 0
-   B_tup = _write_code_Bi_tup(NB)
-   quote
-      @nexprs $NB i -> begin
-         embed_i = basis.embeddings[i]
-         B_i = evaluate(embed_i, X)
-      end
-      A = evaluate(basis.pooling, $B_tup)
-      @nexprs $NB i -> release!(B_i)
-      return A
-   end
-end
-
-function ChainRulesCore.rrule(::typeof(myevaluate), basis::PooledEmebddings{NB, TB}, X::Vector{SVector{3, T}}) where {NB, TB, T}
-   A = myevaluate(basis, X)
-   return A, Δ -> _evaluate_pb(basis, Δ, X)
-end
-
-@generated function _evaluate_pb(basis::PooledEmebddings{NB, TB}, Δ, X) where {NB, TB}
-   B_tup = _write_code_Bi_tup(NB)
-   quote
-      @nexprs $NB i -> begin
-         embed_i = basis.embeddings[i]
-         B_i = evaluate(embed_i, X)
-      end
-      A = evaluate(basis.pooling, $B_tup)
-      pooling_out, pooling_pb = ChainRulesCore.rrule(evaluate, basis.pooling, $B_tup)
-      @nexprs $NB i -> begin
-         _, embed_pb_i = ChainRulesCore.rrule(evaluate, basis.embeddings[i], X)    
-      end
-      # pooling_pb : Vec -> (B_1, B_2, ..., B_NB)
-      # embed_pb_i : B_i -> ∂X
-      ∂X = similar(X)
-      BBs = pooling_pb(Δ)[3]
-      @show typeof(BBs)
-      @nexprs $NB i -> begin
-         ∂X_i = embed_pb_i(BBs[i])
-         @show typeof(∂X_i)
-         ∂X .+= ∂X_i[3]
-      end
-      @show ∂X
-      return ∂X
-   end
-end
-
-end # module PooledEmbed
-
-using Polynomials4ML: legendre_basis, RYlmBasis, ScalarPoly4MLBasis, PooledSparseProduct, OrthPolyBasis1D3T
+using Polynomials4ML: legendre_basis, RYlmBasis, ScalarPoly4MLBasis, PooledSparseProduct, OrthPolyBasis1D3T, PooledEmebddings
 using StaticArrays, LinearAlgebra
 using ObjectPools: acquire!, release!
 using Polynomials4ML
@@ -99,13 +19,15 @@ function Polynomials4ML.evaluate!(Y::AbstractArray, basis::OrthPolyBasis1D3T, X:
    release!(R)
 	return Y
 end
+
 using ChainRulesCore
+
 function ChainRulesCore.rrule(::typeof(Polynomials4ML.evaluate), basis::OrthPolyBasis1D3T, X::Vector{SVector{3, T}}) where T
    R = norm.(X)
    P, dP = evaluate_ed(basis, R)
 
    function pb(∂)
-      ∂X = similar(X)
+      ∂X = zero(X)
       for n = 1:size(dP, 2)
          @simd ivdep for a = 1:length(X)
             ∂X[a] += ∂[a, n] * dP[a, n] * X[a] / R[a]
@@ -114,7 +36,7 @@ function ChainRulesCore.rrule(::typeof(Polynomials4ML.evaluate), basis::OrthPoly
       return (NoTangent(), NoTangent(), ∂X)
    end
 
-  return Y, pb
+  return P, pb
 end
 
 Polynomials4ML._valtype(basis::OrthPolyBasis1D3T{T}, ::Type{<: StaticVector{3, S}}) where {T <: Real, S <: Real} = promote_type(T, S)
@@ -127,9 +49,9 @@ pooling = _generate_basis()
 X = [ @SVector(randn(3)) for i in 1:3 ]
 
 embeddings = (Rnl, Ylm)
-embed_and_pool = PooledEmbed.PooledEmebddings(embeddings, pooling)
-Main.PooledEmbed.myevaluate(embed_and_pool, X)
+embed_and_pool = Polynomials4ML.PooledEmebddings(embeddings, pooling)
+# Polynomials4ML.PooledEmbed.myevaluate(embed_and_pool, X)
 using Zygote
-out, pb = Zygote.pullback(X -> Main.PooledEmbed.myevaluate(embed_and_pool, X), X)
+out, pb = Zygote.pullback(evaluate, embed_and_pool, X)
 
 pb(out)

--- a/test/test_pooledembeddings.jl
+++ b/test/test_pooledembeddings.jl
@@ -1,48 +1,19 @@
-using Polynomials4ML: legendre_basis, RYlmBasis, ScalarPoly4MLBasis, PooledSparseProduct, OrthPolyBasis1D3T, PooledEmebddings
+using Polynomials4ML: legendre_basis, RYlmBasis, ScalarPoly4MLBasis, PooledSparseProduct, OrthPolyBasis1D3T, PooledEmbeddings
 using StaticArrays, LinearAlgebra
 using ObjectPools: acquire!, release!
 using Polynomials4ML
 using ACEbase.Testing: fdtest, print_tf
 using Test
 using Printf
+using Random
+using Lux
+using Zygote
 
 function _generate_basis(; order=2, len = 50)
    NN = [ rand(5:10) for _ = 1:order ]
    spec = sort([ ntuple(t -> rand(1:NN[t]), order) for _ = 1:len])
    return PooledSparseProduct(spec)
 end
-
-function Polynomials4ML.evaluate!(Y::AbstractArray, basis::OrthPolyBasis1D3T, X::Vector{SVector{3, T}}) where T
-   nX = length(X)
-   R = acquire!(basis.pool, :R, (nX,), T)
-   @simd ivdep for i = 1:nX
-      R[i] = norm(X[i])
-   end    
-   evaluate!(Y, basis, R)
-   release!(R)
-	return Y
-end
-
-using ChainRulesCore
-
-function ChainRulesCore.rrule(::typeof(Polynomials4ML.evaluate), basis::OrthPolyBasis1D3T, X::Vector{SVector{3, T}}) where T
-   R = norm.(X)
-   P, dP = evaluate_ed(basis, R)
-
-   function pb(∂)
-      ∂X = zero(X)
-      for n = 1:size(dP, 2)
-         @simd ivdep for a = 1:length(X)
-            ∂X[a] += ∂[a, n] * dP[a, n] * X[a] / R[a]
-         end
-      end
-      return (NoTangent(), NoTangent(), ∂X)
-   end
-
-  return P, pb
-end
-
-Polynomials4ML._valtype(basis::OrthPolyBasis1D3T{T}, ::Type{<: StaticVector{3, S}}) where {T <: Real, S <: Real} = promote_type(T, S)
 
 Rnl = legendre_basis(10)
 Ylm = RYlmBasis(10)
@@ -52,24 +23,55 @@ pooling = _generate_basis()
 X = [ @SVector(randn(3)) for i in 1:3 ]
 
 embeddings = (Rnl, Ylm)
-embed_and_pool = Polynomials4ML.PooledEmebddings(embeddings, pooling)
+embed_and_pool = Polynomials4ML.PooledEmbeddings(embeddings, pooling)
 
 
-# @info("Test evaluate")
-# for ntest = 1:30
-#    bX = [ @SVector(randn(3)) for i in 1:3 ]
-#    evaluate(embed_and_pool, X)
-# end
+@info("Test evaluate")
+for ntest = 1:30
+   bX = [ @SVector(randn(3)) for i in 1:3 ]
+   out = evaluate(embed_and_pool, X)
+   out_Rnl, out_Ylm = Rnl(X), Ylm(X)
+   out_pooling = pooling((out_Rnl, out_Ylm))
+   print_tf(@test out ≈ out_pooling)
+end
 
 @info("Test rrule")
-using Zygote
-for ntest = 1:30
+for ntest = 1:20
+   local bX, bu, u, bA
    bX = [ @SVector(randn(3)) for i in 1:3 ]
    bu = [ @SVector(randn(3)) for i in 1:3 ]
    _BB(t) = bX + t * bu
    bA = evaluate(embed_and_pool, X)
    u = randn(size(bA))
    F(t) = dot(u, Polynomials4ML.evaluate(embed_and_pool, _BB(t)))
+   dF(t) = begin
+      out, pb = Zygote.pullback(evaluate, embed_and_pool, _BB(t))
+      ∂BB = pb(u)[2]
+      return sum( dot(∂BB[i], bu[i]) for i = 1:length(bX) )
+   end
+   print_tf(@test fdtest(F, dF, 0.0; verbose = false))
+end
+
+
+@info("Testing consistency with lux layer")
+l_embed_and_pool = Polynomials4ML.lux(embed_and_pool)
+ps, st = Lux.setup(MersenneTwister(1234), l_embed_and_pool)
+@info("Test evaluate")
+for ntest = 1:30
+   bX = [ @SVector(randn(3)) for i in 1:3 ]
+   print_tf(@test l_embed_and_pool(X, ps, st)[1] ≈ embed_and_pool(X))
+end
+
+
+@info("Testing rrule working correectly")
+for ntest = 1:30
+   local bX, bu, u
+   bX = [ @SVector(randn(3)) for i in 1:3 ]
+   bu = [ @SVector(randn(3)) for i in 1:3 ]
+   _BB(t) = bX + t * bu
+   bA = l_embed_and_pool(X, ps, st)[1]
+   u = randn(size(bA))
+   F(t) = dot(u,  l_embed_and_pool(_BB(t), ps, st)[1])
    dF(t) = begin
       out, pb = Zygote.pullback(evaluate, embed_and_pool, _BB(t))
       ∂BB = pb(u)[2]


### PR DESCRIPTION
Implements `PooledEmbeddings` for double pullback / reverse over reverse 

still WIP

Some notes for myself, we assume that PooledEmbedding has the following struct:

```julia
struct PooledEmbedding{NB, TB <: Tuple} <: AbstractPoly4MLBasis
   embeddings::TB
   pooling::PooledSparseProduct{NB}
   @reqfields()
end
```
and then `TB` is a tuple of embeddings with

```julia
evaluate(embedding, X)
```

and 

```julia
ChainRulesCore.rrule(evaluate, embedding, X)
```
defined.

With  `X isa State` and `X::State + Y::State` also defined (possibly for positions? I don't understand how operations like`+` is defined in `State` yet so I will have to think over this but it should be straight forward.).