### PR TITLE
Fix CI benchmark instructions in docs

### DIFF
--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -50,7 +50,7 @@ show(j.benchmarkgroup)
 
 ## CI Benchmarks
 
-Benchmarks can be run automatically on PR's by adding label "Run Benchmarks" to the PR.
+Benchmarks can be run automatically on PR's by adding label "run benchmark" to the PR.
 
 ## Adding more benchmarks
 


### PR DESCRIPTION
You need to use "run benchmark" not "Run Benchmarks" label to get CI benchmarks run.

This PR is should be used to test that CI benchmark really runs