### PR TITLE
Fix release input in `PooledSparseProduct` and tuple inputs

### DIFF
--- a/src/ace/sparseprodpool.jl
+++ b/src/ace/sparseprodpool.jl
@@ -518,17 +518,15 @@ import LuxCore: AbstractExplicitLayer, initialparameters, initialstates
 struct PooledSparseProductLayer{NB} <: AbstractExplicitLayer 
    basis::PooledSparseProduct{NB}
    meta::Dict{String, Any}
-   use_cache::Bool
    release_input::Bool
 end
 
 function lux(basis::PooledSparseProduct; 
-               use_cache = true, 
                name = String(nameof(typeof(basis))), 
                meta = Dict{String, Any}("name" => name),
                release_input = true)
    @assert haskey(meta, "name")
-   return PooledSparseProductLayer(basis, meta, use_cache, release_input)
+   return PooledSparseProductLayer(basis, meta, release_input)
 end
 
 initialparameters(rng::AbstractRNG, layer::PooledSparseProductLayer) = 

--- a/src/lux.jl
+++ b/src/lux.jl
@@ -66,7 +66,7 @@ function evaluate(l::PolyLuxLayer, X, ps, st)
    out = acquire!(st.pool, _outsym(X), _out_size(l.basis, X), _valtype(l.basis, X))
    evaluate!(out, l.basis, X, ps)
    if l.release_input
-      release!(X)
+      release!.(X)
    end
    return out, st
 end

--- a/test/test_linear.jl
+++ b/test/test_linear.jl
@@ -68,7 +68,8 @@ for (feat, in_size, out_fun) in zip(feature_arr, in_size_arr, out_fun_arr)
          print_tf(@test fdtest(F, dF, 0.0; verbose=false))
       end
    end
-
+   println()
+   
    @info("Testing evaluate")
    for ntest = 1:30
       x = randn(in_size)


### PR DESCRIPTION
Continuing from discussion 1-2 weeks ago on the extra allocations in evaluation of spherical harmonics observed in EQM. The reason is that `PooledSparseProductLayer` did not release layer properly.

Major updates from this PR:

-  Update `PooledSparseProductLayer`, added the `release_input` field
- Broadcast `release_input` in `PolyLuxLayer` for tuple inputs

Minor fix:
- printing format in `LinearLayer`'s test

I also ran the test of EQM locally and it works fine.