### PR TITLE
WIP: Sphericart integration

### DIFF
--- a/src/sphericalharmonics/scrrlm.jl
+++ b/src/sphericalharmonics/scrrlm.jl
@@ -1,0 +1,74 @@
+using SpheriCart: compute, compute_with_gradients, 
+				      compute!, compute_with_gradients!, 
+						SolidHarmonics
+
+export SCRRlmBasis
+
+struct SCRRlmBasis{L, normalisation, static, T} <: SVecPoly4MLBasis
+	basis::SolidHarmonics{L, normalisation, static, T}
+	@reqfields
+end
+
+maxL(basis::SCRRlmBasis{L}) where {L} = L
+
+Base.length(basis::SCRRlmBasis) = sizeY(maxL(basis))
+
+SCRRlmBasis(maxL::Integer, T::Type=Float64) = 
+      SCRRlmBasis( SolidHarmonics(maxL; normalisation = :sphericart, 
+											          static = maxL <= 15, 
+														 T = T))
+
+SCRRlmBasis(srrsh::SolidHarmonics) = 
+      SCRRlmBasis(srrsh, _make_reqfields()...)
+
+natural_indices(basis::SCRRlmBasis) = 
+      [ NamedTuple{(:l, :m)}(idx2lm(i)) for i = 1:length(basis) ]
+
+_valtype(sh::SCRRlmBasis{L, NRM, STATIC, T}, 
+		   ::Type{<: StaticVector{3, S}}) where {L, NRM, STATIC, T <: Real, S <: Real} = 
+		promote_type(T, S)
+
+_valtype(sh::SCRRlmBasis{L, NRM, STATIC, T}, 
+		   ::Type{<: StaticVector{3, Hyper{S}}}) where {L, NRM, STATIC, T <: Real, S <: Real} = 
+		promote_type(T, Hyper{S})
+
+Base.show(io::IO, basis::SCRRlmBasis{L, NRM, STATIC, T}) where {L, NRM, STATIC, T} = 
+      print(io, "SCRRlmBasis(L=$L)")	
+
+# ---------------------- Interfaces
+
+function evaluate!(Y::AbstractArray, basis::SCRRlmBasis, X::SVector{3})
+	Y_temp = reshape(Y, 1, :)
+	compute!(Y_temp, basis.basis, SA[X,])
+	return Y
+end
+
+function evaluate_ed!(Y::AbstractArray, dY::AbstractArray, basis::SCRRlmBasis, X::SVector{3})
+	Y_temp = reshape(Y, 1, :)
+	dY_temp = reshape(dY, 1, :)
+	compute_with_gradients!(Y_temp, dY_temp, basis.basis, SA[X,])
+	return Y, dY
+end
+
+evaluate!(Y::AbstractArray, 
+		    basis::SCRRlmBasis, X::AbstractVector{<: SVector{3}}) = 
+	compute!(Y, basis.basis, X)
+
+evaluate_ed!(Y::AbstractArray, dY::AbstractArray, 
+			    basis::SCRRlmBasis, X::AbstractVector{<: SVector{3}}) = 
+	compute_with_gradients!(Y, dY, basis.basis, X)
+
+# rrule
+function ChainRulesCore.rrule(::typeof(evaluate), basis::SCRRlmBasis, X)
+	A, dX = evaluate_ed(basis, X)
+	function pb(∂A)
+		@assert size(∂A) == (length(X), length(basis))
+		T∂X = promote_type(eltype(∂A), eltype(dX))
+		∂X = similar(X, SVector{3, T∂X})
+		for i = 1:length(X)
+            ∂X[i] = sum([∂A[i,j] * dX[i,j] for j = 1:length(dX[i,:])])
+        end
+		return NoTangent(), NoTangent(), ∂X
+	end
+	return A, pb
+end

--- a/src/sphericalharmonics/sphericalharmonics.jl
+++ b/src/sphericalharmonics/sphericalharmonics.jl
@@ -61,7 +61,9 @@ include("rylm.jl")
 include("crlm.jl")
 include("rrlm.jl")
 
+# SpheriCart - https://github.com/lab-cosmo/sphericart
 include("scylm.jl")
+include("scrrlm.jl")
 
 const XlmBasis = Union{RYlmBasis, CYlmBasis, CRlmBasis, RRlmBasis}
 

--- a/test/ace/test_prodbasis2.jl
+++ b/test/ace/test_prodbasis2.jl
@@ -227,4 +227,5 @@ for ntest = 1:10
    print_tf( @test ∂AA1 ≈ ∂AA2 )
 end 
 
+println()
 ##

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ using Test
     @testset "Complex Solid Harmonics" begin include("sphericalharmonics/test_crlm.jl"); end
     @testset "Real Solid Harmonics" begin include("sphericalharmonics/test_rrlm.jl"); end
     @testset "Real Spherical Harmonics via SpheriCart" begin include("sphericalharmonics/test_scylm.jl"); end
+    @testset "Real Solid Harmonics via SpheriCart" begin include("sphericalharmonics/test_scrrlm.jl"); end
 
     # Quantum Chemistry 
     @testset "Atomic Orbitals Radials" begin include("test_atorbrad.jl"); end

--- a/test/sphericalharmonics/test_scrrlm.jl
+++ b/test/sphericalharmonics/test_scrrlm.jl
@@ -12,46 +12,20 @@ verbose = false
 
 @info("Testing consistency of Real and Complex SH; SpheriCart convention")
 
-# # SpheriCart R2C transformation
-# function ctran3(L)
-#    AA = zeros(ComplexF64, 2L+1, 2L+1)
-#    for i = 1:2L+1
-#        for j in [i, 2L+2-i]
-#            AA[i,j] = begin 
-#                if i == j == L+1
-#                    1
-#                elseif i > L+1 && j > L+1
-#                    (-1)^(i-L-1)/sqrt(2)
-#                elseif i < L+1 && j < L+1
-#                    im/sqrt(2)
-#                elseif i < L+1 && j > L+1
-#                    (-1)^(i-L)/sqrt(2)*im
-#                elseif i > L+1 && j < L+1
-#                    1/sqrt(2)
-#                end
-#            end
-#        end
-#    end
-#    return sparse(AA)
-# end
-
-# function test_r2c_y(L, cY, rY)
-#    Ts = BlockDiagonal([ ctran3(l)' for l = 0:L ]) |> sparse
-#    return cY ≈ Ts * rY
-# end
-
 ##
 
 _maxL = 20
 cSH = RRlmBasis(_maxL)
 rSH = SCRRlmBasis(_maxL)
 
+_R = rand_sphere()
+_scale = evaluate(cSH, _R) ./ evaluate(rSH, _R)
 for nsamples = 1:30
    local R 
    R = rand_sphere()
    cY = evaluate(cSH, R)
    rY = evaluate(rSH, R)
-   print_tf(@test cY ≈ rY)
+   print_tf(@test cY ./ rY ≈ _scale)
 end
 println()
 

--- a/test/sphericalharmonics/test_scrrlm.jl
+++ b/test/sphericalharmonics/test_scrrlm.jl
@@ -5,8 +5,22 @@ using Polynomials4ML: evaluate, evaluate_d, evaluate_ed
 using Polynomials4ML.Testing: print_tf, println_slim 
 using ACEbase.Testing: fdtest
 using HyperDualNumbers: Hyper
+using OffsetArrays
 
 
+import SpheriCart: generate_Flms
+
+function generate_Flms(L::Integer; normalisation = :p4ml, T = Float64)
+   Flm = OffsetMatrix(zeros(L+1, L+1), (-1, -1))
+   @show "new2"
+   for l = 0:L
+      Flm[l, 0] = sqrt(2)
+      for m = 1:l 
+         Flm[l, m] = Flm[l, m-1] / sqrt((l+m) * (l+1-m))
+      end
+   end
+   return Flm
+end
 
 verbose = false
 
@@ -14,17 +28,20 @@ verbose = false
 
 ##
 
-_maxL = 20
-cSH = RRlmBasis(_maxL)
-rSH = SCRRlmBasis(_maxL)
+_maxL = 3
+p4ml_rrlm = RRlmBasis(_maxL)
+sc_rrlm = SCRRlmBasis(_maxL)
 
 _R = rand_sphere()
-_scale = evaluate(cSH, _R) ./ evaluate(rSH, _R)
+_scale = evaluate(p4ml_rrlm, _R) ./ evaluate(sc_rrlm, _R)
+
+
+
 for nsamples = 1:30
    local R 
    R = rand_sphere()
-   cY = evaluate(cSH, R)
-   rY = evaluate(rSH, R)
+   cY = evaluate(p4ml_rrlm, R)
+   rY = evaluate(sc_rrlm, R)
    print_tf(@test cY ./ rY ≈ _scale)
 end
 println()
@@ -35,10 +52,10 @@ println()
 @info("Check consistency of serial and batched evaluation")
 
 X = [ rand_sphere() for i = 1:23 ]
-Y1 = evaluate(rSH, X)
+Y1 = evaluate(sc_rrlm, X)
 Y2 = similar(Y1) 
 for i = 1:length(X)
-   Y2[i, :] = evaluate(rSH, X[i])
+   Y2[i, :] = evaluate(sc_rrlm, X[i])
 end
 println_slim(@test Y1 ≈ Y2)
 
@@ -47,10 +64,10 @@ println_slim(@test Y1 ≈ Y2)
 
 @info("Test: check derivatives of real spherical harmonics")
 for nsamples = 1:30
-   local R, rSH, h 
+   local R, sc_rrlm, h 
    R = @SVector rand(3)
-   rSH = SCRRlmBasis(5)
-   Y, dY = evaluate_ed(rSH, R)
+   sc_rrlm = SCRRlmBasis(5)
+   Y, dY = evaluate_ed(sc_rrlm, R)
    DY = Matrix(transpose(hcat(dY...)))
    errs = []
    verbose && @printf("     h    | error \n")
@@ -60,7 +77,7 @@ for nsamples = 1:30
       Rh = Vector(R)
       for i = 1:3
          Rh[i] += h
-         DYh[:, i] = (evaluate(rSH, SVector(Rh...)) - Y) / h
+         DYh[:, i] = (evaluate(sc_rrlm, SVector(Rh...)) - Y) / h
          Rh[i] -= h
       end
       push!(errs, norm(DY - DYh, Inf))
@@ -76,7 +93,7 @@ println()
 
 @info("Check consistency of serial and batched gradients")
 
-rSH = SCRRlmBasis(10)
+sc_rrlm = SCRRlmBasis(10)
 X = [ rand_sphere() for i = 1:21 ]
 
 x2dualwrtj(x, j) = SVector{3}([Hyper(x[i], i == j, i == j, 0) for i = 1:3])
@@ -84,12 +101,12 @@ x2dualwrtj(x, j) = SVector{3}([Hyper(x[i], i == j, i == j, 0) for i = 1:3])
 hX = [x2dualwrtj(x, 1) for x in X]
 
 
-Y0 = evaluate(rSH, X)
-Y1, dY1 = evaluate_ed(rSH, X)
+Y0 = evaluate(sc_rrlm, X)
+Y1, dY1 = evaluate_ed(sc_rrlm, X)
 Y2 = similar(Y1); dY2 = similar(dY1)
 for i = 1:length(X)
-   Y2[i, :] = evaluate(rSH, X[i])
-   dY2[i, :] = evaluate_ed(rSH, X[i])[2]
+   Y2[i, :] = evaluate(sc_rrlm, X[i])
+   dY2[i, :] = evaluate_ed(sc_rrlm, X[i])[2]
 end
 println_slim(@test Y0 ≈ Y1 ≈ Y2)
 println_slim(@test dY1 ≈ dY2)

--- a/test/sphericalharmonics/test_scrrlm.jl
+++ b/test/sphericalharmonics/test_scrrlm.jl
@@ -1,0 +1,121 @@
+using LinearAlgebra, StaticArrays, Test, Printf, SparseArrays, BlockDiagonals
+using Polynomials4ML, Polynomials4ML.Testing
+using Polynomials4ML: index_y, rand_sphere
+using Polynomials4ML: evaluate, evaluate_d, evaluate_ed 
+using Polynomials4ML.Testing: print_tf, println_slim 
+using ACEbase.Testing: fdtest
+using HyperDualNumbers: Hyper
+
+
+
+verbose = false
+
+@info("Testing consistency of Real and Complex SH; SpheriCart convention")
+
+# # SpheriCart R2C transformation
+# function ctran3(L)
+#    AA = zeros(ComplexF64, 2L+1, 2L+1)
+#    for i = 1:2L+1
+#        for j in [i, 2L+2-i]
+#            AA[i,j] = begin 
+#                if i == j == L+1
+#                    1
+#                elseif i > L+1 && j > L+1
+#                    (-1)^(i-L-1)/sqrt(2)
+#                elseif i < L+1 && j < L+1
+#                    im/sqrt(2)
+#                elseif i < L+1 && j > L+1
+#                    (-1)^(i-L)/sqrt(2)*im
+#                elseif i > L+1 && j < L+1
+#                    1/sqrt(2)
+#                end
+#            end
+#        end
+#    end
+#    return sparse(AA)
+# end
+
+# function test_r2c_y(L, cY, rY)
+#    Ts = BlockDiagonal([ ctran3(l)' for l = 0:L ]) |> sparse
+#    return cY ≈ Ts * rY
+# end
+
+##
+
+_maxL = 20
+cSH = RRlmBasis(_maxL)
+rSH = SCRRlmBasis(_maxL)
+
+for nsamples = 1:30
+   local R 
+   R = rand_sphere()
+   cY = evaluate(cSH, R)
+   rY = evaluate(rSH, R)
+   print_tf(@test cY ≈ rY)
+end
+println()
+
+
+##
+
+@info("Check consistency of serial and batched evaluation")
+
+X = [ rand_sphere() for i = 1:23 ]
+Y1 = evaluate(rSH, X)
+Y2 = similar(Y1) 
+for i = 1:length(X)
+   Y2[i, :] = evaluate(rSH, X[i])
+end
+println_slim(@test Y1 ≈ Y2)
+
+
+##
+
+@info("Test: check derivatives of real spherical harmonics")
+for nsamples = 1:30
+   local R, rSH, h 
+   R = @SVector rand(3)
+   rSH = SCRRlmBasis(5)
+   Y, dY = evaluate_ed(rSH, R)
+   DY = Matrix(transpose(hcat(dY...)))
+   errs = []
+   verbose && @printf("     h    | error \n")
+   for p = 2:10
+      h = 0.1^p
+      DYh = similar(DY)
+      Rh = Vector(R)
+      for i = 1:3
+         Rh[i] += h
+         DYh[:, i] = (evaluate(rSH, SVector(Rh...)) - Y) / h
+         Rh[i] -= h
+      end
+      push!(errs, norm(DY - DYh, Inf))
+      verbose && @printf(" %.2e | %.2e \n", h, errs[end])
+   end
+   success = (minimum(errs[2:end]) < 1e-3 * maximum(errs[1:3])) || (minimum(errs) < 1e-10)
+   print_tf(@test success)
+end
+println()
+
+
+##
+
+@info("Check consistency of serial and batched gradients")
+
+rSH = SCRRlmBasis(10)
+X = [ rand_sphere() for i = 1:21 ]
+
+x2dualwrtj(x, j) = SVector{3}([Hyper(x[i], i == j, i == j, 0) for i = 1:3])
+
+hX = [x2dualwrtj(x, 1) for x in X]
+
+
+Y0 = evaluate(rSH, X)
+Y1, dY1 = evaluate_ed(rSH, X)
+Y2 = similar(Y1); dY2 = similar(dY1)
+for i = 1:length(X)
+   Y2[i, :] = evaluate(rSH, X[i])
+   dY2[i, :] = evaluate_ed(rSH, X[i])[2]
+end
+println_slim(@test Y0 ≈ Y1 ≈ Y2)
+println_slim(@test dY1 ≈ dY2)


### PR DESCRIPTION
This PR aims at integrating SpheriCart [https://github.com/lab-cosmo/sphericart](url) to p4ml. Todo list that I come up with but feel free to update edit. This also fixes a bug that the current real solid harmonics returns `NaN` when an (approximately) zero vector is given or does not evaluate.

- [x] p4ml interface for real solid harmonics in SpheriCart
- [ ] normalization of real solid harmonics in SpheriCart which compatible with current p4ml 

If we want to retire the old backend entirely (though this sounds to me too ambitious):

- [ ] make sure all the laplacian/derivative/pullback/pushforward of previous solid/spherical harmonics can be called exactly the same as before
- [ ] check the normalization is correct for each basis, or provide an option `normlization = :p4ml` which recovers the previous normalization
- [ ] and possibly evaluate the complex spherical harmonics via a transformation? This sounds something to be done in SpheriCart
- [ ] update documentation, and maybe tag a minor version?

CC @zhanglw0521 @TSGut 