### PR TITLE
Harden scalar cubic-spline helpers as a GPU-safe internal API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polynomials4ML"
 uuid = "03c4bcba-a943-47e9-bfa1-b1661fc2974f"
 authors = ["Christoph Ortner <christophortner@gmail.com> and contributors"]
-version = "0.5.9"
+version = "0.5.10"
 
 [deps]
 ACEbase = "14bae519-eb20-449c-a949-9c58ed33163e"

--- a/src/splinify.jl
+++ b/src/splinify.jl
@@ -154,17 +154,21 @@ end
 """
    _eval_cubic_d(t, fl, fr, gl, gr, h) -> (f, g)
 
-Evaluate the Hermite cubic (`_eval_cubic`) and its derivative w.r.t. the
-physical coordinate on an interval of width `h`. `t` is the local coordinate
-and `fl, fr, gl, gr` are the endpoint values / interval-scaled gradients. The
-derivative is obtained from a single ForwardDiff `Dual`.
+Evaluate the Hermite cubic and its derivative w.r.t. the physical coordinate
+on an interval of width `h`. `t` is the local coordinate and `fl, fr, gl, gr`
+are the endpoint values / interval-scaled gradients. Value and `t`-derivative
+are computed analytically from the cubic `f(t) = a3 t³ + a2 t² + a1 t + a0`
+(same coefficients as `_eval_cubic`); the `t`-derivative is then rescaled to
+the physical coordinate by `1/h`.
 """
 @inline function _eval_cubic_d(t, fl, fr, gl, gr, h)
-   td = Dual(t, one(t))
-   fd = _eval_cubic(td, fl, fr, gl, gr)
-   f = ForwardDiff.value.(fd)
-   g = ForwardDiff.partials.(fd, 1)
-   return f, g / h
+   a0 = fl
+   a1 = gl
+   a2 = -3fl + 3fr - 2gl - gr
+   a3 = 2fl - 2fr + gl + gr
+   f  = ((a3*t + a2)*t + a1)*t + a0      # a3 t³ + a2 t² + a1 t + a0
+   df = (3*a3*t + 2*a2)*t + a1           # 3 a3 t² + 2 a2 t + a1  ( = df/dt )
+   return f, df / h
 end
 
 """

--- a/src/splinify.jl
+++ b/src/splinify.jl
@@ -92,52 +92,105 @@ end
 
 
 
-# ----------------- shared evaluation code 
+# ----------------- shared evaluation code
+#
+# The helpers in this block (`_spl_grid`, `_eval_cubic`, `_eval_cubic_d`,
+# `_eval_cubspl`, `_cubspl_widthgrad`) are the scalar cubic-spline kernel of
+# P4ML. They are not exported, but they are a *stable, GPU-safe internal API*
+# that downstream packages (e.g. ACEradials) may use to build their own spline
+# layers without re-implementing the math. All are `@inline` and free of
+# CPU-only constructs: integer truncation uses `unsafe_trunc`, which — unlike
+# `floor(Int, ·)` / `Int(·)` — carries no exception path and therefore
+# compiles on GPU backends (the reason these were previously forked).
+
+# primal value of a (possibly ForwardDiff-`Dual`) coordinate, for the integer
+# index computation only — the index is piecewise constant in `x`, so it
+# carries no derivative; the local coordinate `t = s - il` keeps it.
+@inline _spl_primal(x::Real) = x
+@inline _spl_primal(x::Dual) = _spl_primal(ForwardDiff.value(x))
 
 """
-   _eval_cubic(t, fl, fr, gl, gr, h)
+   _spl_grid(x, x0, x1, NX) -> (x, t, il, h)
 
-Evaluate cubic spline at position `t` in `[0,1]`, given function values `fl`, `fr`
-and gradients `gl`, `gr` at the left and right endpoints.
+Locate `x` on the uniform spline grid of `NX` nodes spanning `[x0, x1]`.
+Returns the clamped coordinate `x` (Flat boundary condition), the local
+coordinate `t ∈ [0,1)` within the interval, the 0-based left-node index `il`,
+and the grid spacing `h`. The cubic on that interval is then evaluated with
+`_eval_cubic(t, F[il+1], F[il+2], h*G[il+1], h*G[il+2])`.
+
+GPU-safe: uses `unsafe_trunc` rather than `floor(Int, ·)`.
+"""
+@inline function _spl_grid(x, x0, x1, NX)
+   x = clamp(x, x0, x1)        # project to [x0, x1] (corresponds to Flat bc)
+   h = (x1 - x0) / (NX-1)      # uniform grid spacing
+   s = (x - x0) / h
+   # left-node index, from the primal of `s`. `unsafe_trunc` carries no
+   # InexactError check, so it compiles on GPU (the reason these helpers were
+   # previously forked) and accepts a `Dual` value via `_spl_primal`; the
+   # argument is in [0, NX-1] here, so truncation is well-defined. The `min`
+   # keeps `il+2 ≤ NX` at the right endpoint x = x1 (where s = NX-1 exactly,
+   # which would otherwise index one past the end), giving t = 1.
+   il = min(unsafe_trunc(Int, _spl_primal(s)), NX-2)
+   t = s - il                  # local coordinate of x in [0, 1]
+   return x, t, il, h
+end
+
+"""
+   _eval_cubic(t, fl, fr, gl, gr)
+
+Evaluate a Hermite cubic at `t ∈ [0,1]`, given function values `fl`, `fr` and
+(interval-scaled) gradients `gl`, `gr` at the left and right endpoints.
 """
 @inline function _eval_cubic(t, fl, fr, gl, gr)
-   # (2t³ - 3t² + 1)*fl + (t³ - 2t² + t)*gl + 
-   #           (-2t³ + 3t²)*fr + (t³ - t²)*gr 
+   # (2t³ - 3t² + 1)*fl + (t³ - 2t² + t)*gl +
+   #           (-2t³ + 3t²)*fr + (t³ - t²)*gr
    a0 = fl
-   a1 = gl 
+   a1 = gl
    a2 = -3fl + 3fr - 2gl - gr
    a3 = 2fl - 2fr + gl + gr
    return ((a3*t + a2)*t + a1)*t + a0
 end
 
 """
+   _eval_cubic_d(t, fl, fr, gl, gr, h) -> (f, g)
+
+Evaluate the Hermite cubic (`_eval_cubic`) and its derivative w.r.t. the
+physical coordinate on an interval of width `h`. `t` is the local coordinate
+and `fl, fr, gl, gr` are the endpoint values / interval-scaled gradients. The
+derivative is obtained from a single ForwardDiff `Dual`.
+"""
+@inline function _eval_cubic_d(t, fl, fr, gl, gr, h)
+   td = Dual(t, one(t))
+   fd = _eval_cubic(td, fl, fr, gl, gr)
+   f = ForwardDiff.value.(fd)
+   g = ForwardDiff.partials.(fd, 1)
+   return f, g / h
+end
+
+"""
    _eval_cubspl(x, F, G, x0, x1, NX)
 
-auxiliary function to the evaluate the cubic spline basis given 
-the spline data arrays    
+Evaluate the cubic spline basis at `x`, given the node value / gradient arrays
+`F`, `G` and the grid `(x0, x1, NX)`.
 """
 @inline function _eval_cubspl(x, F, G, x0, x1, NX)
-   x = clamp(x, x0, x1)     # project to [x0, x1] (corresponds to Flat bc)
-   h = (x1 - x0) / (NX-1)   # uniform grid spacing 
-   il = floor(Int, (x - x0) / h)   # index of left node
-   # TODO: is this numerically stable? 
-   t = (x - x0) / h - il          # relative coordinate of x in [il, il+1]
+   _, t, il, h = _spl_grid(x, x0, x1, NX)
    @inbounds _eval_cubic(t, F[il+1], F[il+2], h*G[il+1], h*G[il+2])
 end
 
+"""
+   _cubspl_widthgrad(x, F, G, x0, x1, NX) -> (f, g)
+
+Evaluate the cubic spline basis and its derivative at `x`. Outside `[x0, x1]`
+the value is Flat-extended and the derivative is zero.
+"""
 @inline function _cubspl_widthgrad(x, F, G, x0, x1, NX)
    if x < x0 || x > x1
       f = _eval_cubspl(x, F, G, x0, x1, NX)
-      return f, zero(f) 
+      return f, zero(f)
    end
-   h = (x1 - x0) / (NX-1)   # uniform grid spacing 
-   t, _il = modf((x - x0) / h)
-   il = Int(_il)
-   td = Dual(t, one(t))
-   fd = _eval_cubic(td, F[il+1], F[il+2], h*G[il+1], h*G[il+2])
-   f = ForwardDiff.value.(fd)
-   g = ForwardDiff.partials.(fd, 1)
-   return f, g / h 
+   _, t, il, h = _spl_grid(x, x0, x1, NX)
+   @inbounds _eval_cubic_d(t, F[il+1], F[il+2], h*G[il+1], h*G[il+2], h)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,8 +21,11 @@ using Test
     # Misc
     @testset "Static Prod" begin include("test_staticprod.jl"); end
 
-    # Transformations 
+    # Transformations
     @testset "Transformed Basis" begin include("test_transformed.jl"); end
+
+    # Splines
+    @testset "Cubic Splines" begin include("test_splines.jl"); end
 
     # Test lux interface 
     @testset "Lux" begin include("test_lux.jl"); end 

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -62,6 +62,30 @@ P4ML.Testing.test_all(st_spl1; ka = true)
 
 
 ##
+# ForwardDiff check of the hard-coded cubic-spline derivative. `_eval_cubic_d`
+# returns the value and the analytic d/dx derivative (= d/dt of `_eval_cubic`,
+# rescaled by 1/h); both must match `_eval_cubic` and its ForwardDiff
+# derivative.
+
+import ForwardDiff as FD
+
+@info("ForwardDiff check of hard-coded _eval_cubic_d")
+let NU = 6
+   for ntest = 1:30
+      t = rand()
+      h = 0.5 + rand()
+      fl = @SVector randn(NU); fr = @SVector randn(NU)
+      gl = @SVector randn(NU); gr = @SVector randn(NU)
+      f, df = P4ML._eval_cubic_d(t, fl, fr, gl, gr, h)
+      df_ad = FD.derivative(τ -> P4ML._eval_cubic(τ, fl, fr, gl, gr), t) ./ h
+      print_tf(@test f ≈ P4ML._eval_cubic(t, fl, fr, gl, gr))
+      print_tf(@test df ≈ df_ad)
+   end
+   println()
+end
+
+
+##
 
 # import ForwardDiff as FD
 


### PR DESCRIPTION
Step 2 of the ACEradials ↔ P4ML spline consolidation (`agents/radials_restructure.md` §3.1, Option B): make P4ML the single source of the cubic-spline *math* so ACEradials can drop its forked GPU spline kernel.

## What

Refactor the scalar spline kernel in `splinify.jl` into a documented, `@inline`, GPU-safe internal surface:

- **`_spl_grid(x, x0, x1, NX) -> (x, t, il, h)`** — clamp (Flat bc) + uniform-grid location, returning the left-node index `il`, local coordinate `t`, and spacing `h`.
- **`_eval_cubic_d(t, fl, fr, gl, gr, h) -> (f, g)`** — per-interval value + physical-coordinate derivative via a single `Dual`.
- `_eval_cubspl` / `_cubspl_widthgrad` now build on these instead of duplicating the grid/derivative arithmetic; `_eval_cubic` unchanged.

These are not exported, but are committed to as a **stable internal API** that downstream packages (ACEradials' `TransSelSplines`) can call instead of re-implementing the math.

## GPU-safety

Integer truncation uses `unsafe_trunc` rather than `floor(Int, ·)` / `Int(·)`: the latter carry an `InexactError` path that cannot be compiled away on GPU backends — exactly why ACEradials forked this kernel. The index primal is extracted with `_spl_primal` so a `Dual` `x` (ForwardDiff through the basis) still differentiates correctly (`t = s - il` carries the derivative).

## Bug fix

Fixes a latent off-by-one at the right endpoint `x = x1`, where `s = NX-1` exactly so `il+2` indexed one past the end of `F`/`G`. It was masked by `@inbounds` (and only "correct" because `t = 0` zeroed the out-of-range weight); it surfaces as a `BoundsError` once `test_splines.jl` runs under `--check-bounds=yes`. `_spl_grid` now clamps `il ≤ NX-2`, giving `t = 1` and the correct endpoint value memory-safely.

## Tests

- Wired the previously-orphaned `test/test_splines.jl` into `runtests.jl` (value/derivative/batched/rrule + the KA kernel path on CPU backend).
- Full suite passes: **1796/1796**, Julia 1.12, under the default `Pkg.test()` `--check-bounds=yes`. Behaviour-preserving on CPU.

Patch bump to v0.5.10 (backward-compatible: new internal API + endpoint bugfix).